### PR TITLE
revert: rollback dayjs and @ant-design/icons upgrades

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -10,12 +10,12 @@
     "setup": "max setup"
   },
   "dependencies": {
-    "@ant-design/icons": "^6.2.5",
+    "@ant-design/icons": "^5.6.1",
     "@ant-design/pro-components": "^2.8.7",
     "@umijs/max": "^4.4.5",
     "@umijs/renderer-react": "^4.6.55",
     "antd": "^5.24.0",
-    "dayjs": "^1.11.21",
+    "dayjs": "^1.11.13",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
   admin:
     dependencies:
       '@ant-design/icons':
-        specifier: ^6.2.5
-        version: 6.2.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^5.6.1
+        version: 5.6.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@ant-design/pro-components':
         specifier: ^2.8.7
         version: 2.8.10(antd@5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(rc-field-form@2.7.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -44,8 +44,8 @@ importers:
         specifier: ^5.24.0
         version: 5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       dayjs:
-        specifier: ^1.11.21
-        version: 1.11.21
+        specifier: ^1.11.13
+        version: 1.11.20
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -99,9 +99,6 @@ packages:
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
 
-  '@ant-design/colors@8.0.1':
-    resolution: {integrity: sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==}
-
   '@ant-design/cssinjs-utils@1.1.3':
     resolution: {integrity: sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==}
     peerDependencies:
@@ -118,10 +115,6 @@ packages:
     resolution: {integrity: sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==}
     engines: {node: '>=8.x'}
 
-  '@ant-design/fast-color@3.0.1':
-    resolution: {integrity: sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==}
-    engines: {node: '>=8.x'}
-
   '@ant-design/icons-svg@4.4.2':
     resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
 
@@ -134,13 +127,6 @@ packages:
 
   '@ant-design/icons@5.6.1':
     resolution: {integrity: sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==}
-    engines: {node: '>=8'}
-    peerDependencies:
-      react: 18.2.0
-      react-dom: 18.2.0
-
-  '@ant-design/icons@6.2.5':
-    resolution: {integrity: sha512-0hKtoKqTjGFOndUyJLJmC9Cg6k4rEO7rLo6xmgbNJH+/ZX1C57RVals2v1j1knHl9n7Q+sBOveTvn931wLOCKw==}
     engines: {node: '>=8'}
     peerDependencies:
       react: 18.2.0
@@ -1355,12 +1341,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0
 
-  '@rc-component/util@1.11.1':
-    resolution: {integrity: sha512-awVlI3ub2vqfqkYxOBc/uQ0efm3jw0wcrhtO/YWLyZfxiKXczKwNbVuhlnyxytDt7H9pbbVQiqr+O6MLATtRYg==}
-    peerDependencies:
-      react: 18.2.0
-      react-dom: 18.2.0
-
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1553,12 +1533,6 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
-
-  '@types/node@25.9.2':
-    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
-
-  '@types/node@25.9.2':
-    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
 
   '@types/node@25.9.2':
     resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
@@ -2439,10 +2413,6 @@ packages:
     resolution: {integrity: sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==}
     engines: {node: '>=6'}
 
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
-
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
@@ -2669,8 +2639,8 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
 
-  dayjs@1.11.21:
-    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3785,9 +3755,6 @@ packages:
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
-
-  is-mobile@5.0.0:
-    resolution: {integrity: sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==}
 
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
@@ -6670,10 +6637,6 @@ snapshots:
     dependencies:
       '@ant-design/fast-color': 2.0.6
 
-  '@ant-design/colors@8.0.1':
-    dependencies:
-      '@ant-design/fast-color': 3.0.1
-
   '@ant-design/cssinjs-utils@1.1.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@ant-design/cssinjs': 1.24.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -6698,8 +6661,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
 
-  '@ant-design/fast-color@3.0.1': {}
-
   '@ant-design/icons-svg@4.4.2': {}
 
   '@ant-design/icons@4.8.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
@@ -6720,15 +6681,6 @@ snapshots:
       '@babel/runtime': 7.29.2
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-
-  '@ant-design/icons@6.2.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@ant-design/colors': 8.0.1
-      '@ant-design/icons-svg': 4.4.2
-      '@rc-component/util': 1.11.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      clsx: 2.1.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
@@ -6843,7 +6795,7 @@ snapshots:
       '@chenshuai2144/sketch-color': 1.0.9(react@18.2.0)
       antd: 4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -6861,7 +6813,7 @@ snapshots:
       '@chenshuai2144/sketch-color': 1.0.9(react@18.2.0)
       antd: 5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -6881,7 +6833,7 @@ snapshots:
       '@umijs/use-params': 1.0.9(react@18.2.0)
       antd: 4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-field-form: 2.7.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -6901,7 +6853,7 @@ snapshots:
       '@umijs/use-params': 1.0.9(react@18.2.0)
       antd: 5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-field-form: 2.7.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -6963,7 +6915,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       antd: 4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       rc-resize-observer: 1.4.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-util: 4.21.1
       react: 18.2.0
@@ -6982,7 +6934,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       antd: 5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       rc-resize-observer: 1.4.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-util: 4.21.1
       react: 18.2.0
@@ -6996,7 +6948,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@ctrl/tinycolor': 3.6.1
       antd: 4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7008,7 +6960,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@ctrl/tinycolor': 3.6.1
       antd: 5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7044,7 +6996,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@18.2.0)
       antd: 4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-field-form: 2.7.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -7069,7 +7021,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@18.2.0)
       antd: 5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-field-form: 2.7.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -7085,7 +7037,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       antd: 4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -7101,7 +7053,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       antd: 5.29.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       lodash: 4.18.1
       lodash-es: 4.18.1
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -8141,13 +8093,6 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@rc-component/util@1.11.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      is-mobile: 5.0.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.3.1
-
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sinclair/typebox@0.27.10': {}
@@ -8345,14 +8290,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/minimist@1.2.5': {}
-
-  '@types/node@25.9.2':
-    dependencies:
-      undici-types: 7.24.6
-
-  '@types/node@25.9.2':
-    dependencies:
-      undici-types: 7.24.6
 
   '@types/node@25.9.2':
     dependencies:
@@ -8874,11 +8811,11 @@ snapshots:
       '@tanstack/react-query-devtools': 4.44.0(@tanstack/react-query@4.44.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@umijs/bundler-utils': 4.6.55
       '@umijs/valtio': 1.0.4(@types/react@18.3.28)(react@18.2.0)
-      antd-dayjs-webpack-plugin: 1.0.6(dayjs@1.11.21)
+      antd-dayjs-webpack-plugin: 1.0.6(dayjs@1.11.20)
       axios: 0.27.2
       babel-plugin-import: 1.13.8
       babel-plugin-styled-components: 2.1.4(@babel/core@7.29.0)(styled-components@6.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       dva-core: 2.0.4(redux@4.2.1)
       dva-immer: 1.0.2(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       dva-loading: 3.0.25(dva-core@2.0.4(redux@4.2.1))
@@ -9267,9 +9204,9 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  antd-dayjs-webpack-plugin@1.0.6(dayjs@1.11.21):
+  antd-dayjs-webpack-plugin@1.0.6(dayjs@1.11.20):
     dependencies:
-      dayjs: 1.11.21
+      dayjs: 1.11.20
 
   antd@4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -9335,7 +9272,7 @@ snapshots:
       '@rc-component/trigger': 2.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames: 2.5.1
       copy-to-clipboard: 3.3.3
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       rc-cascader: 3.34.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-checkbox: 3.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-collapse: 3.9.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -9351,7 +9288,7 @@ snapshots:
       rc-motion: 2.9.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-notification: 5.6.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-pagination: 5.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      rc-picker: 4.11.3(date-fns@2.30.0)(dayjs@1.11.21)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      rc-picker: 4.11.3(date-fns@2.30.0)(dayjs@1.11.20)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-progress: 4.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-rate: 2.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-resize-observer: 1.4.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -9828,8 +9765,6 @@ snapshots:
     dependencies:
       is-regexp: 2.1.0
 
-  clsx@2.1.1: {}
-
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -10073,7 +10008,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
 
-  dayjs@1.11.21: {}
+  dayjs@1.11.20: {}
 
   debug@2.6.9:
     dependencies:
@@ -11462,8 +11397,6 @@ snapshots:
       is-docker: 3.0.0
 
   is-map@2.0.3: {}
-
-  is-mobile@5.0.0: {}
 
   is-negative-zero@2.0.3: {}
 
@@ -13009,7 +12942,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       classnames: 2.5.1
       date-fns: 2.30.0
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       moment: 2.30.1
       rc-trigger: 5.3.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       rc-util: 5.44.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -13017,7 +12950,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0
 
-  rc-picker@4.11.3(date-fns@2.30.0)(dayjs@1.11.21)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  rc-picker@4.11.3(date-fns@2.30.0)(dayjs@1.11.20)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.29.2
       '@rc-component/trigger': 2.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -13029,7 +12962,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
     optionalDependencies:
       date-fns: 2.30.0
-      dayjs: 1.11.21
+      dayjs: 1.11.20
       moment: 2.30.1
 
   rc-progress@3.4.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0):


### PR DESCRIPTION
## 变更内容

回滚以下两个依赖升级 PR：

- Revert #38：dayjs 1.11.20 -> 1.11.21
- Revert #37：@ant-design/icons -> 6.2.5

## 变更原因

这两个依赖升级后导致 CI 构建失败：

- Node CI / admin build
- Node CI / collector build

为了先恢复主分支稳定性，暂时回滚这两个依赖升级。

## 测试方式

- [ ] Node CI / admin build
- [ ] Node CI / collector build
- [ ] CI 全部通过后再合并